### PR TITLE
Sending job data with request + fixing history page bugs

### DIFF
--- a/app/Http/Controllers/guestController.php
+++ b/app/Http/Controllers/guestController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs;
 use App\redshifts;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\DB;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use GuzzleHttp\Client;
@@ -42,8 +44,18 @@ class guestController extends Controller
      */
     public function store(Request $request)
     {
-    	$galaxy = array();
+		//creating job entry in the database
+		$userId = 1;
+		$job = new Jobs();
+		$job->job_name = "guest job name";
+		$job->job_description = "guest job description";
+		$job->user_id = $userId;
+		$job->save();
+		$lastJob = DB::table('jobs')->latest('job_id')->where('user_id','=', $userId)->first();
+		$jobId = $lastJob->job_id;
 
+		//creating data to send in http json request
+    	$galaxy = array();
 		$galaxy[0] = new redshifts();
 		$galaxy[0]->assigned_calc_ID = $request->input('assigned_calc_ID');
 		$galaxy[0]->optical_u = $request->input('optical_u');
@@ -63,6 +75,7 @@ class guestController extends Controller
 		$galaxy[0]->toJson();
 
 		$galaxy[1] = new redshifts();
+		$galaxy[1]->job_id = $jobId;
 		$galaxy[1]->methods = $request->input('methods');
 		//todo - this is reliant on guest being id 1 in the users table.
 		$galaxy[1]->user_ID = 1;

--- a/resources/views/history.blade.php
+++ b/resources/views/history.blade.php
@@ -102,106 +102,146 @@
 						<th>Job name</th><th>Description</th><th>Submitted at</th><th>Duration</th>
 					</tr>
 					</thead>
-					<!-- might need to go below the tbody -->
 					@foreach($jobs as $job)
 						@php
+							$skipFlag = 0;
 							$uniqueJobId = $job->job_id;
-							$jobCreatedAt = $job->created_at;
-							$jobClosedAt = DB::select('SELECT calculations.created_at FROM calculations
-								INNER JOIN redshifts ON calculations.galaxy_id = redshifts.calculation_id
-								WHERE redshifts.job_id = '.$uniqueJobId .' ORDER BY calculations.created_at DESC
-								LIMIT 1');
-							//dump($jobCreatedAt);
-							//dump($jobClosedAt[0]->created_at);
-							$jobStartTime = strtotime($jobCreatedAt);
-							$jobFinishTime = strtotime($jobClosedAt[0]->created_at);
-							$intervalSeconds = ($jobFinishTime-$jobStartTime);
+							$jobCounterNullCheck = 0;
 
-							if($intervalSeconds < 60){
-								$interval = round($intervalSeconds, 2) . " seconds";
+							//checks that a job actually has some redshifts
+							$jobCounterNullCheck = DB::select('SELECT job_id, count(*) as total
+									FROM redshifts
+									WHERE job_id = '.$uniqueJobId);
+
+							//checks that all redshifts in a job have completed
+							if($jobCounterNullCheck[0]->total != 0){
+								$jobCounter = DB::select('SELECT job_id, count(*) as total
+									FROM redshifts
+									WHERE (status = "PROCESSING" OR status = "SUBMITTED")
+									AND job_id = '.$uniqueJobId);
 							}
-							elseif ($intervalSeconds < 3600){
-								//minutes
-								$interval = round(($intervalSeconds/60), 2) . " minutes";
-							}
-							elseif ($intervalSeconds < 86400){
-								//hours
-								$interval = round(($intervalSeconds/(60*60)), 2) . " hours";
+
+
+
+
+
+							//basically, only show results where ALL redshifts in a job have had the status flag set to
+							//COMPLETED OR READ, which is the indication from the API that the calculation row for the redshift
+							//has been written.
+							if(($jobCounter[0]->total == 0) && ($jobCounterNullCheck != 0)){
+
+
+								$jobCreatedAt = $job->created_at;
+								$jobClosedAt = DB::select('SELECT calculations.created_at FROM calculations
+									INNER JOIN redshifts ON calculations.galaxy_id = redshifts.calculation_id
+									WHERE redshifts.job_id = '.$uniqueJobId .' ORDER BY calculations.created_at DESC
+									LIMIT 1');
+
+								$jobStartTime = strtotime($jobCreatedAt);
+								$jobFinishTime = strtotime($jobClosedAt[0]->created_at);
+								$intervalSeconds = ($jobFinishTime-$jobStartTime);
+
+								if($intervalSeconds < 60){
+									$interval = round($intervalSeconds, 2) . " seconds";
+								}
+								elseif ($intervalSeconds < 3600){
+									//minutes
+									$interval = round(($intervalSeconds/60), 2) . " minutes";
+								}
+								elseif ($intervalSeconds < 86400){
+									//hours
+									$interval = round(($intervalSeconds/(60*60)), 2) . " hours";
+								}
+								else{
+									//days
+									$interval = round(($intervalSeconds/(60*60*24)), 2) . " days";
+								}
+
 							}
 							else{
-								//days
-								$interval = round(($intervalSeconds/(60*60*24)), 2) . " days";
+								//setting skipflag as continues don't work within the else statement
+								//skipflag is 0 ONLY when NO redshifts in a job are submitted/processing,
+								// AND when there is at least redshift associated with the job to prevent fresh
+								//jobs that have not had values written by the API breaking the page
+								$skipFlag = 1;
 							}
 						@endphp
-					<tbody>
-					<tr class="view">
-						<td>{{ $job->job_name }}</td>
-						<td>{{ $job->job_description }}</td>
-						<td>{{ $job->created_at }}</td>
-						<td>{{ $interval }}</td>
-					</tr>
-					<tr class="fold">
-						<td colspan="7">
-							<div class="fold-content">
-								<h3>{{ $job->job_name }}</h3>
-								<p>{{ $job->job_description }}</p>
-								<table>
-									<thead>
-									<tr>
-										<th>Galaxy ID</th>
-										<th>Optical u</th>
-										<th>Optical v</th>
-										<th>Optical g</th>
-										<th>Optical r</th>
-										<th>Optical i</th>
-										<th>Optical z</th>
-										<th>Infrared 3.6</th>
-										<th>Infrared 4.5</th>
-										<th>Infrared 5.8</th>
-										<th>Infrared 8.0</th>
-										<th>Infrared J</th>
-										<th>Infrared H</th>
-										<th>Infrared K</th>
-										<th>Radio 1.4</th>
-										<th>Method</th>
-										<th>Redshift result</th>
 
-									</tr>
-									</thead>
-									<tbody>
+						@if($skipFlag == 0)
 
-									@php
-										$calculations = DB::select('SELECT redshifts.*, redshift_result, method_name FROM calculations
-											INNER JOIN redshifts ON calculations.galaxy_id = redshifts.calculation_id
-											INNER JOIN methods on calculations.method_id = methods.method_id
-											WHERE redshifts.job_id = '.$uniqueJobId);
-									@endphp
-									@foreach($calculations as $calculation)
-									<tr>
-										<td>{{ $calculation->assigned_calc_id }}</td>
-										<td>{{ $calculation->optical_u }}</td>
-										<td>{{ $calculation->optical_v }}</td>
-										<td>{{ $calculation->optical_g }}</td>
-										<td>{{ $calculation->optical_r }}</td>
-										<td>{{ $calculation->optical_i }}</td>
-										<td>{{ $calculation->optical_z }}</td>
-										<td>{{ $calculation->infrared_three_six }}</td>
-										<td>{{ $calculation->infrared_four_five }}</td>
-										<td>{{ $calculation->infrared_five_eight }}</td>
-										<td>{{ $calculation->infrared_eight_zero }}</td>
-										<td>{{ $calculation->infrared_J }}</td>
-										<td>{{ $calculation->infrared_H }}</td>
-										<td>{{ $calculation->infrared_K }}</td>
-										<td>{{ $calculation->radio_one_four }}</td>
-										<td>{{ $calculation->method_name }}</td>
-										<td>{{ $calculation->redshift_result }}</td>
-									</tr>
-									@endforeach
-									</tbody>
-								</table>
-							</div>
-						</td>
-					</tr>
+							<tbody>
+							<tr class="view">
+								<td>{{ $job->job_name }}</td>
+								<td>{{ $job->job_description }}</td>
+								<td>{{ $job->created_at }}</td>
+								<td>{{ $interval }}</td>
+							</tr>
+							<tr class="fold">
+								<td colspan="7">
+									<div class="fold-content">
+										<h3>{{ $job->job_name }}</h3>
+										<p>{{ $job->job_description }}</p>
+										<table>
+											<thead>
+											<tr>
+												<th>Galaxy ID</th>
+												<th>Optical u</th>
+												<th>Optical v</th>
+												<th>Optical g</th>
+												<th>Optical r</th>
+												<th>Optical i</th>
+												<th>Optical z</th>
+												<th>Infrared 3.6</th>
+												<th>Infrared 4.5</th>
+												<th>Infrared 5.8</th>
+												<th>Infrared 8.0</th>
+												<th>Infrared J</th>
+												<th>Infrared H</th>
+												<th>Infrared K</th>
+												<th>Radio 1.4</th>
+												<th>Method</th>
+												<th>Redshift result</th>
+
+											</tr>
+											</thead>
+											<tbody>
+
+											@php
+												$calculations = DB::select('SELECT redshifts.*, redshift_result, method_name FROM calculations
+													INNER JOIN redshifts ON calculations.galaxy_id = redshifts.calculation_id
+													INNER JOIN methods on calculations.method_id = methods.method_id
+													WHERE redshifts.job_id = '.$uniqueJobId);
+											@endphp
+											@foreach($calculations as $calculation)
+												<tr>
+													<td>{{ $calculation->assigned_calc_id }}</td>
+													<td>{{ $calculation->optical_u }}</td>
+													<td>{{ $calculation->optical_v }}</td>
+													<td>{{ $calculation->optical_g }}</td>
+													<td>{{ $calculation->optical_r }}</td>
+													<td>{{ $calculation->optical_i }}</td>
+													<td>{{ $calculation->optical_z }}</td>
+													<td>{{ $calculation->infrared_three_six }}</td>
+													<td>{{ $calculation->infrared_four_five }}</td>
+													<td>{{ $calculation->infrared_five_eight }}</td>
+													<td>{{ $calculation->infrared_eight_zero }}</td>
+													<td>{{ $calculation->infrared_J }}</td>
+													<td>{{ $calculation->infrared_H }}</td>
+													<td>{{ $calculation->infrared_K }}</td>
+													<td>{{ $calculation->radio_one_four }}</td>
+													<td>{{ $calculation->method_name }}</td>
+													<td>{{ $calculation->redshift_result }}</td>
+												</tr>
+											@endforeach
+											</tbody>
+										</table>
+									</div>
+								</td>
+							</tr>
+
+						@endif
+
+
 
 					@endforeach
 


### PR DESCRIPTION
Added job_id to request being sent to API in the final row with other metadata. Leaving user_id in the request despite it being redundant thanks to the new foreign key links as it may make things a bit easier for the API team. History page no longer breaks when viewing immediately after submitting (i.e., a job has been created but no redshifts/calculations have been written yet), and only shows jobs where all redshifts have finished processing (i.e. status = COMPLETED or READ).